### PR TITLE
Add Blog Post link to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # rn-architecture
-Sample application to demonstrate concepts described in blog post on React Native architecture
+Sample application to demonstrate concepts described in [blog post on React Native architecture](https://medium.com/the-andela-way/how-to-structure-a-react-native-app-for-scale-a29194cd33fc)


### PR DESCRIPTION
The About text for the repository links to a [blog post at uxenthusiast.com](http://www.uxenthusiast.com/react-native/2017/12/30/architecting-for-scale-react-native.html) which is currently broken. Adding a link to the medium post in the meantime.